### PR TITLE
Fix handling of responses to match spec.

### DIFF
--- a/webdriver/transport.py
+++ b/webdriver/transport.py
@@ -19,8 +19,8 @@ class Response(object):
     def __repr__(self):
         return "wdclient.Response(status=%d, body=%s)" % (self.status, self.body)
 
-    @staticmethod
-    def from_http_response(http_response):
+    @classmethod
+    def from_http_response(cls, http_response):
         status = http_response.status
         body = http_response.read()
 
@@ -45,7 +45,7 @@ class Response(object):
             #      with a key `value` set to the JSON Serialization of data.
             assert "value" in body
 
-        return Response(status, body)
+        return cls(status, body)
 
 class HTTPWireProtocol(object):
     """Transports messages (commands and responses) over the WebDriver


### PR DESCRIPTION
Error responses don't have a 'value' wrapper, but they havee
and 'error' key. If we get an error we want to throw always, including
in session-related commands. Since 'value' is returned on every
response we always want to unwrap the value parts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wdclient/9)
<!-- Reviewable:end -->
