### PR TITLE
Update format of "Create Session" command

### DIFF
--- a/webdriver/client.py
+++ b/webdriver/client.py
@@ -272,13 +272,11 @@ class UserPrompt(object):
 
 
 class Session(object):
-    def __init__(self, host, port, url_prefix="/", desired_capabilities=None,
-                 required_capabilities=None, timeout=transport.HTTP_TIMEOUT,
-                 extension=None):
+    def __init__(self, host, port, url_prefix="/", capabilities=None,
+                 timeout=transport.HTTP_TIMEOUT, extension=None):
         self.transport = transport.HTTPWireProtocol(
             host, port, url_prefix, timeout=timeout)
-        self.desired_capabilities = desired_capabilities
-        self.required_capabilities = required_capabilities
+        self.capabilities = capabilities
         self.session_id = None
         self.timeouts = None
         self.window = None
@@ -309,13 +307,8 @@ class Session(object):
 
         body = {}
 
-        caps = {}
-        if self.desired_capabilities is not None:
-            caps["desiredCapabilities"] = self.desired_capabilities
-        if self.required_capabilities is not None:
-            caps["requiredCapabilities"] = self.required_capabilities
-        #body["capabilities"] = caps
-        body = caps
+        if self.capabilities is not None:
+            body["capabilities"] = self.capabilities
 
         value = self.send_command("POST", "session", body=body)
         self.session_id = value["sessionId"]


### PR DESCRIPTION
Use the latest format when issuing the "Create Session" command.

@andreastt The patch is not ready to be merged its current state, but I wanted
some bases for discussion.

Would you like to continue to define the two properties via dedicated Python
keyword arguments? If so, would you prefer `first_match`/`always_match` or
`capabilities_first_match`/`capabilities_always_match`? Alternatively, what
would you think about simply implementing this as a single argument named
`capabilities`? This would make the API and internals a little simpler,
although it would also make possible invalid configurations such as
`Session({"capabilities": {"foo": "bar"}})`. The fact that the property names
have changed recently probably warrants some type checking, though at that
point, maybe it's best to just expose the two properties as separate arguments
after all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wdclient/13)
<!-- Reviewable:end -->
